### PR TITLE
Added new `wait` alias for `await` logger (#73)

### DIFF
--- a/types.js
+++ b/types.js
@@ -32,6 +32,11 @@ module.exports = {
     color: 'green',
     label: 'success'
   },
+  wait: {
+    badge: figures.ellipsis,
+    color: 'blue',
+    label: 'waiting'
+  },
   warn: {
     badge: figures.warning,
     color: 'yellow',


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
